### PR TITLE
Fixed podspec resource pattern to not include the demo app info plist fi...

### DIFF
--- a/CSSSelectorConverter.podspec
+++ b/CSSSelectorConverter.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files           = 'CSSSelectorConverter/CSS*.{m,h}'
   s.prefix_header_contents = "#import \"CSSSelectorConverter.h\""
   s.requires_arc           = true
-  s.resources              = 'CSSSelectorConverter/*.{txt,plist}'
+  s.resources              = ['CSSSelectorConverter/*.{txt}', 'CSSSelectorConverter/CSSSelectorParser.plist']
 end


### PR DESCRIPTION
...le (CSSSelectorConverter/CSSSelectorConverter-Info.plist)

This caused great trouble for me because the `CSSSelectorConverter-Info.plist` file ended up in the root of my app bundle and that confused some script in my CI toolchain.